### PR TITLE
Improve Cgreen Reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'codewars/riscv' }}
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: bin/run multiply
 
       - name: Run multiply-failing example
-        run: bin/run multiply-failing
+        run: bin/run multiply-failing || true
 
       - name: Run syntax-error example
         run: bin/run syntax-error || true

--- a/examples/multiply-failing/solution_tests.c
+++ b/examples/multiply-failing/solution_tests.c
@@ -9,6 +9,9 @@ Describe(Multiply);
 BeforeEach(Multiply) {}
 AfterEach(Multiply) {}
 
+Ensure(Multiply, missing_assertion) {
+}
+
 Ensure(Multiply, works_for_some_fixed_tests) {
   assert_that(multiply(3, 5), is_equal_to(15));
   assert_that(multiply(5, 3), is_equal_to(15));
@@ -31,6 +34,7 @@ Ensure(Multiply, works_for_100_random_tests) {
 
 TestSuite *solution_tests() {
   TestSuite *suite = create_test_suite();
+  add_test_with_context(suite, Multiply, missing_assertion);
   add_test_with_context(suite, Multiply, works_for_some_fixed_tests);
   add_test_with_context(suite, Multiply, works_for_100_random_tests);
   return suite;

--- a/examples/multiply-failing/solution_tests.c
+++ b/examples/multiply-failing/solution_tests.c
@@ -24,7 +24,8 @@ Ensure(Multiply, works_for_100_random_tests) {
     int a = rand() % 100;
     int b = rand() % 100;
     int expected = a * b;
-    assert_that(multiply(a, b), is_equal_to(expected));
+    // assert_that(multiply(a, b), is_equal_to(expected));
+    assert_equal_with_message(multiply(a, b), expected, "multiply(%d, %d) == %d", a, b, expected);
   }
 }
 

--- a/workspace/codewars_reporter.c
+++ b/workspace/codewars_reporter.c
@@ -83,6 +83,19 @@ static void codewars_reporter_show_fail(TestReporter *reporter, const char *file
   printf("\n");
 }
 
+// When a test fails to complete
+static void codewars_reporter_show_incomplete(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
+  printf("\n<ERROR::>");
+  if (message == NULL) {
+    printf("Test Terminated Unexpectedly");
+  } else {
+    char *escaped_message = create_codewars_escape_message(message);
+    vprintf(escaped_message, arguments);
+    free(escaped_message);
+  }
+  printf("\n");
+}
+
 static void codewars_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
   clock_t ts_diff = clock() - pop_ts((struct ts_node **)&reporter->memo);
   // This function increments passes/failures counts.
@@ -109,6 +122,7 @@ TestReporter *create_codewars_reporter() {
   reporter->start_suite = &codewars_reporter_start_suite;
   reporter->start_test = &codewars_reporter_start_test;
   reporter->show_fail = &codewars_reporter_show_fail;
+  reporter->show_incomplete = &codewars_reporter_show_incomplete;
   reporter->finish_test = &codewars_reporter_finish_test;
   reporter->finish_suite = &codewars_reporter_finish_suite;
   reporter->memo = NULL;

--- a/workspace/codewars_reporter.c
+++ b/workspace/codewars_reporter.c
@@ -75,10 +75,6 @@ static void codewars_reporter_start_test(TestReporter *reporter, const char *nam
   push_ts((struct ts_node **)&reporter->memo);
 }
 
-static void codewars_reporter_show_pass(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
-  printf("\n<PASSED::>Test Passed\n");
-}
-
 static void codewars_reporter_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
   printf("\n<FAILED::>");
   char *escaped_message = create_codewars_escape_message(message);
@@ -91,6 +87,9 @@ static void codewars_reporter_finish_test(TestReporter *reporter, const char *fi
   clock_t ts_diff = clock() - pop_ts((struct ts_node **)&reporter->memo);
   // This function increments passes/failures counts.
   reporter_finish_test(reporter, filename, line, message);
+  if (reporter->passes > 0 && reporter->failures == 0 && reporter->exceptions == 0 && reporter->skips == 0) {
+    printf("\n<PASSED::>Test Passed\n");
+  }
   // Increment the totals. `total_failures` is used to determine the exit code.
   reporter->total_passes += reporter->passes;
   reporter->total_failures += reporter->failures;
@@ -109,7 +108,6 @@ TestReporter *create_codewars_reporter() {
   TestReporter *reporter = create_reporter();
   reporter->start_suite = &codewars_reporter_start_suite;
   reporter->start_test = &codewars_reporter_start_test;
-  reporter->show_pass = &codewars_reporter_show_pass;
   reporter->show_fail = &codewars_reporter_show_fail;
   reporter->finish_test = &codewars_reporter_finish_test;
   reporter->finish_suite = &codewars_reporter_finish_suite;

--- a/workspace/codewars_reporter.c
+++ b/workspace/codewars_reporter.c
@@ -68,6 +68,10 @@ static void codewars_reporter_start_suite(TestReporter *reporter, const char *na
 static void codewars_reporter_start_test(TestReporter *reporter, const char *name) {
   printf("\n<IT::>%s\n", name);
   reporter_start_test(reporter, name);
+  reporter->passes = 0;
+  reporter->failures = 0;
+  reporter->skips = 0;
+  reporter->exceptions = 0;
   push_ts((struct ts_node **)&reporter->memo);
 }
 
@@ -85,7 +89,13 @@ static void codewars_show_fail(TestReporter *reporter, const char *file, int lin
 
 static void codewars_reporter_finish_test(TestReporter *reporter, const char *filename, int line, const char *message) {
   clock_t ts_diff = clock() - pop_ts((struct ts_node **)&reporter->memo);
+  // This function increments passes/failures counts.
   reporter_finish_test(reporter, filename, line, message);
+  // Increment the totals. `total_failures` is used to determine the exit code.
+  reporter->total_passes += reporter->passes;
+  reporter->total_failures += reporter->failures;
+  reporter->total_skips += reporter->skips;
+  reporter->total_exceptions += reporter->exceptions;
   printf("\n<COMPLETEDIN::>%ld\n", 1000 * ts_diff / CLOCKS_PER_SEC);
 }
 

--- a/workspace/codewars_reporter.c
+++ b/workspace/codewars_reporter.c
@@ -100,8 +100,12 @@ static void codewars_reporter_finish_test(TestReporter *reporter, const char *fi
   clock_t ts_diff = clock() - pop_ts((struct ts_node **)&reporter->memo);
   // This function increments passes/failures counts.
   reporter_finish_test(reporter, filename, line, message);
-  if (reporter->passes > 0 && reporter->failures == 0 && reporter->exceptions == 0 && reporter->skips == 0) {
-    printf("\n<PASSED::>Test Passed\n");
+  if (reporter->failures == 0 && reporter->exceptions == 0 && reporter->skips == 0) {
+    if (reporter->passes > 0) {
+      printf("\n<PASSED::>Test Passed\n");
+    } else {
+      printf("\n<ERROR::>Missing Assertions\n");
+    }
   }
   // Increment the totals. `total_failures` is used to determine the exit code.
   reporter->total_passes += reporter->passes;

--- a/workspace/codewars_reporter.c
+++ b/workspace/codewars_reporter.c
@@ -75,11 +75,11 @@ static void codewars_reporter_start_test(TestReporter *reporter, const char *nam
   push_ts((struct ts_node **)&reporter->memo);
 }
 
-static void codewars_show_pass(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
+static void codewars_reporter_show_pass(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
   printf("\n<PASSED::>Test Passed\n");
 }
 
-static void codewars_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
+static void codewars_reporter_show_fail(TestReporter *reporter, const char *file, int line, const char *message, va_list arguments) {
   printf("\n<FAILED::>");
   char *escaped_message = create_codewars_escape_message(message);
   vprintf(escaped_message, arguments);
@@ -109,8 +109,8 @@ TestReporter *create_codewars_reporter() {
   TestReporter *reporter = create_reporter();
   reporter->start_suite = &codewars_reporter_start_suite;
   reporter->start_test = &codewars_reporter_start_test;
-  reporter->show_pass = &codewars_show_pass;
-  reporter->show_fail = &codewars_show_fail;
+  reporter->show_pass = &codewars_reporter_show_pass;
+  reporter->show_fail = &codewars_reporter_show_fail;
   reporter->finish_test = &codewars_reporter_finish_test;
   reporter->finish_suite = &codewars_reporter_finish_suite;
   reporter->memo = NULL;


### PR DESCRIPTION
- Fix exit code by setting `total_failures`
- Fix function names
- Only output `<PASSED::>` once per test
- Report unexpected test termination
- Fail tests with missing assertions